### PR TITLE
Add OCR support and demo PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@
 3. Run `pnpm install` to install dependencies
 4. Run `pnpm prisma generate` to generate the Prisma client
 5. Run `pnpm dev` to start the development server
+6. Open the app and click **Use Demo PDF** to test with the bundled sample document
 
 ## Roadmap
 
 - [ ] Add some rate limiting by IP address
-- [ ] Integrate OCR for image parsing in PDFs
+- [x] Integrate OCR for image parsing in PDFs
 - [ ] Add a bit more polish (make the link icon nicer) & add a "powered by Together" sign
 - [ ] Implement additional revision steps for improved summaries
-- [ ] Add a demo PDF for new users to be able to see it in action
+- [x] Add a demo PDF for new users to be able to see it in action
 - [ ] Add feedback system with thumbs up/down feature

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-dropzone": "^14.3.5",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
+    "tesseract.js": "^2.1.5",
     "together-ai": "^0.15.2",
     "ws": "^8.18.0",
     "zod": "^3.24.3",

--- a/public/demo.pdf
+++ b/public/demo.pdf
@@ -1,0 +1,37 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 54 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Demo PDF for SmartPDFs) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000273 00000 n 
+
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+415
+%EOF

--- a/src/components/HomeLandingDrop.tsx
+++ b/src/components/HomeLandingDrop.tsx
@@ -90,6 +90,21 @@ export const HomeLandingDrop = ({
                 </div>
               )}
             </Dropzone>
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-2 self-start"
+              onClick={async () => {
+                const res = await fetch("/demo.pdf");
+                const blob = await res.blob();
+                const demoFile = new File([blob], "demo.pdf", {
+                  type: "application/pdf",
+                });
+                setFile(demoFile);
+              }}
+            >
+              Use Demo PDF
+            </Button>
             <label className="mt-8 text-gray-500" htmlFor="language">
               Language
             </label>

--- a/src/lib/summarize.ts
+++ b/src/lib/summarize.ts
@@ -1,5 +1,6 @@
 import { PDFDocumentProxy } from "pdfjs-dist";
 import assert from "assert";
+import Tesseract from "tesseract.js";
 
 export type Chunk = {
   text: string;
@@ -35,6 +36,19 @@ export async function getPdfText(pdf: PDFDocumentProxy) {
         pageText += item.str;
         lastY = item.transform[5];
       }
+    }
+
+    if (pageText.trim().length === 0) {
+      const viewport = page.getViewport({ scale: 2 });
+      const canvas = document.createElement("canvas");
+      const context = canvas.getContext("2d");
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      await page.render({ canvasContext: context!, viewport }).promise;
+      const {
+        data: { text },
+      } = await Tesseract.recognize(canvas, "eng");
+      pageText = text;
     }
 
     fullText += pageText + "\n\n"; // Add double newline between pages


### PR DESCRIPTION
## Summary
- integrate Tesseract OCR in `src/lib/summarize.ts`
- add demo PDF for new users
- provide a button to load the demo in the home page
- document new demo option in README
- update roadmap items

## Testing
- `npx prettier -w README.md package.json src/components/HomeLandingDrop.tsx src/lib/summarize.ts`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6847234827a8832ca67c6f30b0ca2f64